### PR TITLE
MOVED correctTemp function from example to init function

### DIFF
--- a/examples/i2c_background/i2c_background.ino
+++ b/examples/i2c_background/i2c_background.ino
@@ -14,11 +14,6 @@ void setup()
   //Use the commented line below instead to use the default I2C address.
   Dps310PressureSensor.begin(Wire);
 
-  // IMPORTANT NOTE
-  //If you face the issue that the DPS310 indicates a temperature around 60 °C although it should be around 20 °C (room temperature), you might have got an IC with a fuse bit problem
-  //Call the following function directly after begin() to resolve this issue (needs only be called once after startup)
-  //Dps310PressureSensor.correctTemp();
-
   //temperature measure rate (value from 0 to 7)
   //2^temp_mr temperature measurement results per second
   int16_t temp_mr = 2;

--- a/examples/i2c_command/i2c_command.ino
+++ b/examples/i2c_command/i2c_command.ino
@@ -15,11 +15,6 @@ void setup()
   //Use the commented line below instead of the one above to use the default I2C address.
   //if you are using the Pressure 3 click Board, you need 0x76
   Dps310PressureSensor.begin(Wire);
-  
-  // IMPORTANT NOTE
-  //If you face the issue that the DPS310 indicates a temperature around 60 °C although it should be around 20 °C (room temperature), you might have got an IC with a fuse bit problem
-  //Call the following function directly after begin() to resolve this issue (needs only be called once after startup)
-  //Dps310PressureSensor.correctTemp();
 
   Serial.println("Init complete!");
 }

--- a/examples/i2c_interrupt/i2c_interrupt.ino
+++ b/examples/i2c_interrupt/i2c_interrupt.ino
@@ -24,11 +24,6 @@ void setup()
   //Dps310PressureSensor.begin(Wire, 0x76);
   //Use the commented line below instead to use the default I2C address.
   Dps310PressureSensor.begin(Wire);
-
-  // IMPORTANT NOTE
-  //If you face the issue that the DPS310 indicates a temperature around 60 °C although it should be around 20 °C (room temperature), you might have got an IC with a fuse bit problem
-  //Call the following function directly after begin() to resolve this issue (needs only be called once after startup)
-  //Dps310PressureSensor.correctTemp();
   
   int16_t ret = Dps310PressureSensor.setInterruptPolarity(1);
   ret = Dps310PressureSensor.setInterruptSources(1, 0, 0);

--- a/examples/spi_background/spi_background.ino
+++ b/examples/spi_background/spi_background.ino
@@ -15,11 +15,6 @@ void setup()
   //Call begin to initialize Dps310
   //The parameter pin_nr is the number of the CS pin on your Microcontroller
   Dps310PressureSensor.begin(SPI, pin_cs);
-  
-  // IMPORTANT NOTE
-  //If you face the issue that the DPS310 indicates a temperature around 60 °C although it should be around 20 °C (room temperature), you might have got an IC with a fuse bit problem
-  //Call the following function directly after begin() to resolve this issue (needs only be called once after startup)
-  //Dps310PressureSensor.correctTemp();
 
   //temperature measure rate (value from 0 to 7)
   //2^temp_mr temperature measurement results per second

--- a/examples/spi_command/spi_command.ino
+++ b/examples/spi_command/spi_command.ino
@@ -15,11 +15,6 @@ void setup()
   //Call begin to initialize Dps310PressureSensor
   //The parameter pin_nr is the number of the CS pin on your Microcontroller
   Dps310PressureSensor.begin(SPI, pin_cs);
-  
-  // IMPORTANT NOTE
-  //If you face the issue that the DPS310 indicates a temperature around 60 °C although it should be around 20 °C (room temperature), you might have got an IC with a fuse bit problem
-  //Call the following function directly after begin() to resolve this issue (needs only be called once after startup)
-  //Dps310PressureSensor.correctTemp();
 
   Serial.println("Init complete!");
 }

--- a/examples/spi_interrupt/spi_interrupt.ino
+++ b/examples/spi_interrupt/spi_interrupt.ino
@@ -32,11 +32,6 @@ void setup()
   //  For three wire interface, MISO has to be connected to SDI and there hase to be a resistor between MISO and MOSI
   //  I successfully tested this with a resistor of 1k, but I won't give you any warranty that this works for your equipment too
   Dps310PressureSensor.begin(SPI, pin_cs, 1);
-  
-  // IMPORTANT NOTE
-  //If you face the issue that the DPS310 indicates a temperature around 60 °C although it should be around 20 °C (room temperature), you might have got an IC with a fuse bit problem
-  //Call the following function directly after begin() to resolve this issue (needs only be called once after startup)
-  //Dps310PressureSensor.correctTemp();
 
   //config Dps310 for Interrupts
   int16_t ret = Dps310PressureSensor.setInterruptPolarity(1);

--- a/src/Dps310.cpp
+++ b/src/Dps310.cpp
@@ -914,6 +914,10 @@ void Dps310::init(void)
 
 	//make sure the DPS310 is in standby after initialization
 	standby();	
+
+	// Fix IC with a fuse bit problem, which lead to a wrong temperature 
+	// Should not affect ICs without this problem
+	correctTemp();
 }
 
 


### PR DESCRIPTION
Function does not have an effect, when IC has no fuse bit problem.
Therefore it can be placed inside the init function