### PR TITLE
Measure functions must standby() if the startMeasure functions return DPS__FAIL_TOOBUSY

### DIFF
--- a/src/DpsClass.cpp
+++ b/src/DpsClass.cpp
@@ -212,6 +212,10 @@ int16_t DpsClass::measureTempOnce(float &result, uint8_t oversamplingRate)
 	int16_t ret = startMeasureTempOnce(oversamplingRate);
 	if (ret != DPS__SUCCEEDED)
 	{
+		if (ret == DPS__FAIL_TOOBUSY)
+		{
+			standby();
+		}
 		return ret;
 	}
 
@@ -269,6 +273,10 @@ int16_t DpsClass::measurePressureOnce(float &result, uint8_t oversamplingRate)
 	int16_t ret = startMeasurePressureOnce(oversamplingRate);
 	if (ret != DPS__SUCCEEDED)
 	{
+		if (ret == DPS__FAIL_TOOBUSY)
+		{
+			standby();
+		}
 		return ret;
 	}
 


### PR DESCRIPTION
I think the functions measureTempOnce() & measurePressureOnce() need to standby() if the DPS is in DPS__FAIL_TOOBUSY. 